### PR TITLE
Add formatError call

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var path = require('path');
 var fs = require('fs');
 var EOL = require('os').EOL;
 
-var TAPReporter = function (baseReporterDecorator, rootConfig, logger, helper) {
+var TAPReporter = function (baseReporterDecorator, rootConfig, logger, helper, formatError) {
   var log = logger.create('karma-tap-pretty-reporter');
   var config = rootConfig.tapReporter || {};
   var disableStdout = config.disableStdout === true;
@@ -66,7 +66,7 @@ var TAPReporter = function (baseReporterDecorator, rootConfig, logger, helper) {
     write('not ok ' + ++numbers[browser.id] + ' ' + result.description + EOL);
     write('  ---' + EOL);
     for (var key in resultLog) {
-      write('    ' + key + ': ' + resultLog[key] + EOL);
+      write(formatError('    ' + key + ': ' + resultLog[key] + EOL));
     }
     write('  ...' + EOL);
   };
@@ -130,7 +130,7 @@ var TAPReporter = function (baseReporterDecorator, rootConfig, logger, helper) {
   }
 };
 
-TAPReporter.$inject = ['baseReporterDecorator', 'config', 'logger', 'helper'];
+TAPReporter.$inject = ['baseReporterDecorator', 'config', 'logger', 'helper', 'formatError'];
 
 module.exports = {
   'reporter:tap-pretty': ['type', TAPReporter]


### PR DESCRIPTION
Allows for formatting the error message.

Before
<img width="863" alt="Screen Shot 2020-01-21 at 7 16 42 PM" src="https://user-images.githubusercontent.com/360826/72854523-a0d5c280-3c82-11ea-8eae-563c60bf0352.png">


After with 

```js
    formatError(msg) {
      msg = msg.replace(/\([^<]+/igm, '');
      return msg;
    },
```

<img width="761" alt="Screen Shot 2020-01-21 at 7 17 07 PM" src="https://user-images.githubusercontent.com/360826/72854533-a7643a00-3c82-11ea-92b8-dc0aad6ae1e2.png">
